### PR TITLE
Feature/override format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ GoogleTranslate::unlessLanguageIs('en', string $text);
 GoogleTranslate::justTranslate(string $text): string
 ```
 
+- There is is an optional third parameter for format to take advantage for better html translation support. Google Translate API currently supports 'text' and 'html' as parameters. The default for this parameter is 'text' as it has the best use case for most translations. 
+[Google Translate API Docs](https://cloud.google.com/translate/docs/reference/rest/v2/translate)
+
+```php
+GoogleTranslate::unlessLanguageIs('en', string $text, string $format);
+```
+
 - There is also a nice blade helper called `@translate` that comes with the package to make its use more neat in the view files. It accepts an optional second argument which is the language code you want the string to be translated in. You can specify the default option in the config file.
 
 ```

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -52,14 +52,14 @@ class GoogleTranslate
         return $translations;
     }
 
-    public function translate($input, $to = null): array
+    public function translate($input, $to = null, $format = 'text'): array
     {
         $translateTo = $to ?? config('googletranslate.default_target_translation');
 
         $translateTo = $this->sanitizeLanguageCode($translateTo);
 
         if (is_array($input)) {
-            return $this->translateBatch($input, $translateTo);
+            return $this->translateBatch($input, $translateTo, $format);
         }
 
         $response = $this
@@ -87,13 +87,13 @@ class GoogleTranslate
         return $response['text'];
     }
 
-    public function translateBatch(array $input, string $translateTo): array
+    public function translateBatch(array $input, string $translateTo, $format = 'text'): array
     {
         $translateTo = $this->sanitizeLanguageCode($translateTo);
 
         $responses = $this
             ->translateClient
-            ->translateBatch($input, $translateTo);
+            ->translateBatch($input, $translateTo, $format);
 
         foreach ($responses as $response) {
             $translations[] = [

--- a/src/GoogleTranslateClient.php
+++ b/src/GoogleTranslateClient.php
@@ -33,16 +33,16 @@ class GoogleTranslateClient
             ->detectLanguageBatch($input);
     }
 
-    public function translate(string $text, string $translateTo)
+    public function translate(string $text, string $translateTo, string $format = 'text')
     {
         return $this->translate
-            ->translate($text, ['target' => $translateTo, 'format' => 'text']);
+            ->translate($text, ['target' => $translateTo, 'format' => $format]);
     }
 
-    public function translateBatch(array $input, string $translateTo)
+    public function translateBatch(array $input, string $translateTo, string $format = 'text')
     {
         return $this->translate
-            ->translateBatch($input, ['target' => $translateTo, 'format' => 'text']);
+            ->translateBatch($input, ['target' => $translateTo, 'format' => $format]);
     }
 
     public function getAvaliableTranslationsFor(string $languageCode)

--- a/tests/GoogleTranslateTest.php
+++ b/tests/GoogleTranslateTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 class GoogleTranslateTest extends TestCase
 {
     public $testString = 'A test string';
+    public $testHtmlString = '<p>A test string</p>';
 
     private $translateClient;
 
@@ -88,10 +89,28 @@ class GoogleTranslateTest extends TestCase
     }
 
     /** @test */
+    public function it_can_translate_the_html_string_passed_to_it()
+    {
+        $this->translateClient
+            ->shouldReceive('translate')->with($this->testHtmlString, 'hi')
+            ->once()
+            ->andReturn(['source' => 'en', 'text' => '']);
+
+        $response = $this->translate->translate($this->testHtmlString, 'hi', 'html');
+
+        $this->assertIsArray($response);
+
+        $this->assertArrayHasKey('source_text', $response);
+        $this->assertArrayHasKey('source_language_code', $response);
+        $this->assertArrayHasKey('translated_text', $response);
+        $this->assertArrayHasKey('translated_language_code', $response);
+    }
+
+    /** @test */
     public function it_can_translate_an_array_of_strings_passed_to_it()
     {
         $this->translateClient
-            ->shouldReceive('translateBatch')->with([$this->testString, $this->testString], 'hi')
+            ->shouldReceive('translateBatch')->with([$this->testString, $this->testString], 'hi', 'text')
             ->once()
             ->andReturn([
                 ['source' => 'en', 'text' => '', 'input' => $this->testString],


### PR DESCRIPTION
Allow the package to have formats passed as a 3rd parameter.
This allows users to now specify a HTML format and get more accurate results from translating strings of HTML.

No breaking changes as this still defaults to text if nothing is passed in.