### PR TITLE
Feature/validate input text

### DIFF
--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -3,6 +3,7 @@
 namespace JoggApp\GoogleTranslate;
 
 use Exception;
+use InvalidArgumentException;
 use JoggApp\GoogleTranslate\Traits\SupportedLanguages;
 
 class GoogleTranslate
@@ -163,11 +164,11 @@ class GoogleTranslate
     protected function validateInput($input): void
     {
         if(is_array($input) && in_array(null, $input)) {
-            throw new \InvalidArgumentException('Input string cannot be null');
+            throw new InvalidArgumentException('Input string cannot be null');
         }
 
         if(is_null($input)) {
-            throw new \InvalidArgumentException('Input string cannot be null');
+            throw new InvalidArgumentException('Input string cannot be null');
         }
 
         return;

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -24,6 +24,8 @@ class GoogleTranslate
             return $this->detectLanguageBatch($input);
         }
 
+        $this->validateInput($input);
+
         $response = $this
             ->translateClient
             ->detectLanguage($input);
@@ -37,6 +39,8 @@ class GoogleTranslate
 
     public function detectLanguageBatch(array $input): array
     {
+        $this->validateInput($input);
+
         $responses = $this
             ->translateClient
             ->detectLanguageBatch($input);
@@ -54,6 +58,8 @@ class GoogleTranslate
 
     public function translate($input, $to = null, $format = 'text'): array
     {
+        $this->validateInput($input);
+
         $translateTo = $to ?? config('googletranslate.default_target_translation');
 
         $translateTo = $this->sanitizeLanguageCode($translateTo);
@@ -76,6 +82,8 @@ class GoogleTranslate
 
     public function justTranslate(string $input, $to = null): string
     {
+        $this->validateInput($input);
+
         $translateTo = $to ?? config('googletranslate.default_target_translation');
 
         $translateTo = $this->sanitizeLanguageCode($translateTo);
@@ -90,6 +98,8 @@ class GoogleTranslate
     public function translateBatch(array $input, string $translateTo, $format = 'text'): array
     {
         $translateTo = $this->sanitizeLanguageCode($translateTo);
+
+        $this->validateInput($input);
 
         $responses = $this
             ->translateClient
@@ -148,5 +158,18 @@ class GoogleTranslate
             "Invalid or unsupported ISO 639-1 language code -{$languageCode}-,
             get the list of valid and supported language codes by running GoogleTranslate::languages()"
         );
+    }
+
+    protected function validateInput($input)
+    {
+        if(is_array($input) && in_array(null, $input)) {
+            throw new \InvalidArgumentException('Input string cannot be null');
+        }
+
+        if(is_null($input)) {
+            throw new \InvalidArgumentException('Input string cannot be null');
+        }
+
+        return;
     }
 }

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -160,7 +160,7 @@ class GoogleTranslate
         );
     }
 
-    protected function validateInput($input)
+    protected function validateInput($input): void
     {
         if(is_array($input) && in_array(null, $input)) {
             throw new \InvalidArgumentException('Input string cannot be null');

--- a/tests/GoogleTranslateTest.php
+++ b/tests/GoogleTranslateTest.php
@@ -202,4 +202,28 @@ class GoogleTranslateTest extends TestCase
         );
         $this->translate->sanitizeLanguageCode('xx');
     }
+
+    /** @test */
+    public function it_validates_input_against_null_strings()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->translate->translate(null, 'en');
+        $this->translate->justTranslate(null, 'en');
+    }
+
+    /** @test */
+    public function it_validates_input_against_null_strings_in_a_batch()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->translate->translateBatch([null, null], 'en');
+    }
+
+    /** @test */
+    public function it_validates_input_agaisnt_null_strings_when_detecting_a_language()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->translate->detectLanguage(null);
+        $this->translate->detectLanguage([null, null]);
+        $this->translate->detectLanguageBatch([null, null]);
+    }
 }


### PR DESCRIPTION
Hey,
I came across a usecase where I was looping over some user content, and when they hadn't entered anything into a field I was getting an error (null string), while I had a try catch over this I wasn't get any feedback saying that it was invalid, so It was never caught.

While I do need to validate or not pass to the translate api myself I thought it'd be useful to have a Not Valid Arguement exception thrown for this. 

This shouldn't break any code anyone has as it would be erroring out anyway. 
Added in tests for the funationality too. 

Extracted it to a method so if there are anymore things that should be validated agaisnt, they can be put in there with their exceptions.