### PR TITLE
Update to use latest Google Translate client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 Thumbs.db
 phpunit.xml
 /.idea
+.phpunit.result.cache

--- a/config/googletranslate.php
+++ b/config/googletranslate.php
@@ -1,21 +1,21 @@
 <?php
 
 return [
-  /*
-    |----------------------------------------------------------------------------------------------------
-    | The ISO 639-1 code of the language in lowercase to which the text will be translated to by default.
-    |----------------------------------------------------------------------------------------------------
-    */
-  'default_target_translation' => 'en',
+    /*
+      |----------------------------------------------------------------------------------------------------
+      | The ISO 639-1 code of the language in lowercase to which the text will be translated to by default.
+      |----------------------------------------------------------------------------------------------------
+      */
+    'default_target_translation' => 'en',
 
-  /*
-    |-------------------------------------------------------------------------------
-    | Api Key generated within Google Cloud Dashboard.
-    |
-    | The process to get this file is documented in a step by step detailed manner
-    | over here:
-    | https://github.com/JoggApp/laravel-google-translate/blob/master/google.md
-    |-------------------------------------------------------------------------------
-    */
-  'api_key' => env('GOOGLE_TRANSLATE_API_KEY'),
+    /*
+      |-------------------------------------------------------------------------------
+      | Api Key generated within Google Cloud Dashboard.
+      |
+      | The process to get this file is documented in a step by step detailed manner
+      | over here:
+      | https://github.com/JoggApp/laravel-google-translate/blob/master/google.md
+      |-------------------------------------------------------------------------------
+      */
+    'api_key' => env('GOOGLE_TRANSLATE_API_KEY'),
 ];

--- a/config/googletranslate.php
+++ b/config/googletranslate.php
@@ -1,21 +1,21 @@
 <?php
 
 return [
-    /*
+  /*
     |----------------------------------------------------------------------------------------------------
     | The ISO 639-1 code of the language in lowercase to which the text will be translated to by default.
     |----------------------------------------------------------------------------------------------------
     */
-    'default_target_translation' => 'en',
+  'default_target_translation' => 'en',
 
-    /*
+  /*
     |-------------------------------------------------------------------------------
-    | Path to the json file containing the authentication credentials.
+    | Api Key generated within Google Cloud Dashboard.
     |
     | The process to get this file is documented in a step by step detailed manner
     | over here:
     | https://github.com/JoggApp/laravel-google-translate/blob/master/google.md
     |-------------------------------------------------------------------------------
     */
-    'key_file_path' => base_path('composer.json'),
+  'api_key' => env('GOOGLE_TRANSLATE_API_KEY'),
 ];

--- a/google.md
+++ b/google.md
@@ -6,12 +6,11 @@
 
 <img width="576" alt="screen shot 2018-10-11 at 12 11 19 am" src="https://user-images.githubusercontent.com/11228182/46759117-29c62600-ccec-11e8-99a2-b23ee035a75d.png">
 
-- Select the project you just created, and go the "Create Service Account Key" page and in the 'Service Account' section click on 'New Service Account'.
+- Select the project you just created, and go the "APIs & Services" -> "Credentials" using the navigation.
 
-- Enter the name & select the Role as 'Owner' for the project.
+- Click at the "Create credentials" dropdown button and choose "API key". To prevent unauthorized use and quota theft, restrict your key to limit how it can be used.
 
-- Then click on create to have the JSON credentials file downloaded automatically.
-
-- Add that json file in your laravel project root & add it to `.gitignore`.
-
-- Set the path to that file as the value for the key `key_file_path` in the `config/googletranslate.php` (config file published by this package).
+- Now, you can use this key to set a package-specific environment variable:
+```
+GOOGLE_TRANSLATE_API_KEY=AIzaS.....
+```

--- a/src/GoogleTranslateClient.php
+++ b/src/GoogleTranslateClient.php
@@ -8,66 +8,65 @@ use JoggApp\GoogleTranslate\Traits\SupportedLanguages;
 
 class GoogleTranslateClient
 {
-  use SupportedLanguages;
+    use SupportedLanguages;
 
-  private $translate;
+    private $translate;
 
-  public function __construct(array $config)
-  {
-    $this->checkForInvalidConfiguration($config);
-
-    $this->translate = new TranslateClient([
-      'key' => $config['api_key']
-    ]);
-  }
-
-  public function detectLanguage(string $text)
-  {
-    return $this->translate
-      ->detectLanguage($text);
-  }
-
-  public function detectLanguageBatch(array $input)
-  {
-    return $this->translate
-      ->detectLanguageBatch($input);
-  }
-
-  public function translate(string $text, string $translateTo, string $format = 'text')
-  {
-    return $this->translate
-      ->translate($text, ['target' => $translateTo, 'format' => $format]);
-  }
-
-  public function translateBatch(array $input, string $translateTo, string $format = 'text')
-  {
-    return $this->translate
-      ->translateBatch($input, ['target' => $translateTo, 'format' => $format]);
-  }
-
-  public function getAvaliableTranslationsFor(string $languageCode)
-  {
-    return $this->translate
-      ->localizedLanguages(['target' => $languageCode]);
-  }
-
-  private function checkForInvalidConfiguration(array $config)
-  {
-    if (!isset($config['api_key']) || $config['api_key'] === null) {
-      throw new Exception('Google Api Key is required.');
+    public function __construct(array $config)
+    {
+        $this->checkForInvalidConfiguration($config);
+        $this->translate = new TranslateClient([
+            'key' => $config['api_key'],
+        ]);
     }
 
-    $codeInConfig = $config['default_target_translation'];
+    public function detectLanguage(string $text)
+    {
+        return $this->translate
+            ->detectLanguage($text);
+    }
 
-    $languageCodeIsValid = is_string($codeInConfig)
-      && ctype_lower($codeInConfig)
-      && in_array($codeInConfig, $this->languages());
+    public function detectLanguageBatch(array $input)
+    {
+        return $this->translate
+            ->detectLanguageBatch($input);
+    }
 
-    if (!$languageCodeIsValid) {
-      throw new Exception(
-        'The default_target_translation value in the config/googletranslate.php file should
+    public function translate(string $text, string $translateTo, string $format = 'text')
+    {
+        return $this->translate
+            ->translate($text, ['target' => $translateTo, 'format' => $format]);
+    }
+
+    public function translateBatch(array $input, string $translateTo, string $format = 'text')
+    {
+        return $this->translate
+            ->translateBatch($input, ['target' => $translateTo, 'format' => $format]);
+    }
+
+    public function getAvaliableTranslationsFor(string $languageCode)
+    {
+        return $this->translate
+            ->localizedLanguages(['target' => $languageCode]);
+    }
+
+    private function checkForInvalidConfiguration(array $config)
+    {
+        if ( ! isset($config['api_key']) || $config['api_key'] === null) {
+            throw new Exception('Google Api Key is required.');
+        }
+
+        $codeInConfig = $config['default_target_translation'];
+
+        $languageCodeIsValid = is_string($codeInConfig)
+            && ctype_lower($codeInConfig)
+            && in_array($codeInConfig, $this->languages());
+
+        if ( ! $languageCodeIsValid) {
+            throw new Exception(
+                'The default_target_translation value in the config/googletranslate.php file should
                 be a valid lowercase ISO 639-1 code of the language'
-      );
+            );
+        }
     }
-  }
 }

--- a/src/GoogleTranslateClient.php
+++ b/src/GoogleTranslateClient.php
@@ -3,71 +3,71 @@
 namespace JoggApp\GoogleTranslate;
 
 use Exception;
-use Google\Cloud\Translate\TranslateClient;
+use Google\Cloud\Translate\V2\TranslateClient;
 use JoggApp\GoogleTranslate\Traits\SupportedLanguages;
 
 class GoogleTranslateClient
 {
-    use SupportedLanguages;
+  use SupportedLanguages;
 
-    private $translate;
+  private $translate;
 
-    public function __construct(array $config)
-    {
-        $this->checkForInvalidConfiguration($config);
+  public function __construct(array $config)
+  {
+    $this->checkForInvalidConfiguration($config);
 
-        $this->translate = new TranslateClient([
-            'keyFilePath' => $config['key_file_path']
-        ]);
+    $this->translate = new TranslateClient([
+      'key' => $config['api_key']
+    ]);
+  }
+
+  public function detectLanguage(string $text)
+  {
+    return $this->translate
+      ->detectLanguage($text);
+  }
+
+  public function detectLanguageBatch(array $input)
+  {
+    return $this->translate
+      ->detectLanguageBatch($input);
+  }
+
+  public function translate(string $text, string $translateTo, string $format = 'text')
+  {
+    return $this->translate
+      ->translate($text, ['target' => $translateTo, 'format' => $format]);
+  }
+
+  public function translateBatch(array $input, string $translateTo, string $format = 'text')
+  {
+    return $this->translate
+      ->translateBatch($input, ['target' => $translateTo, 'format' => $format]);
+  }
+
+  public function getAvaliableTranslationsFor(string $languageCode)
+  {
+    return $this->translate
+      ->localizedLanguages(['target' => $languageCode]);
+  }
+
+  private function checkForInvalidConfiguration(array $config)
+  {
+    if (!isset($config['api_key']) || $config['api_key'] === null) {
+      throw new Exception('Google Api Key is required.');
     }
 
-    public function detectLanguage(string $text)
-    {
-        return $this->translate
-            ->detectLanguage($text);
-    }
+    $codeInConfig = $config['default_target_translation'];
 
-    public function detectLanguageBatch(array $input)
-    {
-        return $this->translate
-            ->detectLanguageBatch($input);
-    }
+    $languageCodeIsValid = is_string($codeInConfig)
+      && ctype_lower($codeInConfig)
+      && in_array($codeInConfig, $this->languages());
 
-    public function translate(string $text, string $translateTo, string $format = 'text')
-    {
-        return $this->translate
-            ->translate($text, ['target' => $translateTo, 'format' => $format]);
-    }
-
-    public function translateBatch(array $input, string $translateTo, string $format = 'text')
-    {
-        return $this->translate
-            ->translateBatch($input, ['target' => $translateTo, 'format' => $format]);
-    }
-
-    public function getAvaliableTranslationsFor(string $languageCode)
-    {
-        return $this->translate
-            ->localizedLanguages(['target' => $languageCode]);
-    }
-
-    private function checkForInvalidConfiguration(array $config)
-    {
-        if (!file_exists($config['key_file_path'])) {
-            throw new Exception('The json file does not exist at the given path');
-        }
-
-        $codeInConfig = $config['default_target_translation'];
-
-        $languageCodeIsValid = is_string($codeInConfig)
-            && ctype_lower($codeInConfig)
-            && in_array($codeInConfig, $this->languages());
-
-        if (!$languageCodeIsValid) {
-            throw new Exception(
-                'The default_target_translation value in the config/googletranslate.php file should
+    if (!$languageCodeIsValid) {
+      throw new Exception(
+        'The default_target_translation value in the config/googletranslate.php file should
                 be a valid lowercase ISO 639-1 code of the language'
-            );
-        }
+      );
     }
+  }
 }


### PR DESCRIPTION
The currently used TranslateClient is deprecated.

With that PR we introduce V2 and concurrently a switch to the use of Google Cloud Api Keys for authentication.
This makes setup easier since only a single key is needed that can be set as an env variable.
(Also makes it easier to run an app using that package within a CI/CD process).

Fyi: there is some formatting as well done by PHPStorm Laravel-Code-Formatter preset

Happy new year!