### PR TITLE
Allow empty string as source language for auto-detection

### DIFF
--- a/config/googletranslate.php
+++ b/config/googletranslate.php
@@ -4,6 +4,8 @@ return [
     /*
       |----------------------------------------------------------------------------------------------------
       | The ISO 639-1 code of the default source language.
+      |
+      | You may as well leave an empty string '' for automatic source language detection.
       |----------------------------------------------------------------------------------------------------
       */
     'default_source_translation' => 'en',


### PR DESCRIPTION
This pull request reverts possibility of automatic source language detection.

Normally, when we do not pass `'source'` in `$options` array to Google, the translation engine tries to detect it automatically (without an additional API call).

Now, it's possible to use empty string as the source language either explicitly at `translate()` / `translateBatch()` methods or generally in config at `'default_source_translation'`.